### PR TITLE
Add simple Telegram forward message handler

### DIFF
--- a/ManageMessage.js
+++ b/ManageMessage.js
@@ -1,0 +1,1 @@
+console.log('ManageMessage process started');

--- a/index.js
+++ b/index.js
@@ -1,0 +1,21 @@
+const TelegramBot = require('node-telegram-bot-api');
+const { spawn } = require('child_process');
+
+const token = process.env.BOT_TOKEN;
+if (!token) {
+  console.error('BOT_TOKEN environment variable is required');
+  process.exit(1);
+}
+
+const bot = new TelegramBot(token, { polling: true });
+
+bot.on('message', (msg) => {
+  // Listen to any message in a group
+  if (msg.chat && (msg.chat.type === 'group' || msg.chat.type === 'supergroup')) {
+    // Check if the message is a forwarded message
+    if (msg.forward_from || msg.forward_from_chat) {
+      // Start the ManageMessage process
+      spawn('ManageMessage', [], { stdio: 'inherit' });
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   },
   "author": "",
   "license": "ISC",
-  "description": ""
+  "description": "",
+  "dependencies": {
+    "node-telegram-bot-api": "^0.61.0"
+  }
 }


### PR DESCRIPTION
## Summary
- add Telegram bot dependency
- implement bot in `index.js` to listen for forwarded messages
- launch `ManageMessage` process when a forward is detected

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68578558e42c832e885eabafed465749