### PR TITLE
Implement forwarded message deduplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .idea/
+forward_dedup.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Telegram Group Manager
+
+This bot handles voice messages and forwarded messages in Telegram groups. Voice messages are transcribed using OpenAI Whisper. Forwarded messages are summarized in Hebrew using GPT-4.
+
+## Forwarded message deduplication
+
+The bot keeps track of processed forwarded messages for each chat. When a forwarded message arrives, a unique key is built from the original chat and message ID when available, falling back to a hash of the text.
+
+If the message was already processed in that chat, the new copy is deleted and the sender is tagged with a link to the first appearance. Otherwise the message is summarized and recorded. The data is persisted to `forward_dedup.json` so deduplication survives restarts.


### PR DESCRIPTION
## Summary
- persist processed forwarded messages in `forward_dedup.json`
- skip summarizing a forwarded message if it was already processed in the same chat
- document the deduplication behaviour
- ignore the deduplication file from git

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857a245cfec832eb38fe6860cf11aa8